### PR TITLE
fix: check if package from location.txt exists before processing it

### DIFF
--- a/unitypackage_godot/scenes/browser/browser.gd
+++ b/unitypackage_godot/scenes/browser/browser.gd
@@ -61,6 +61,11 @@ func load_imported_pacakges():
 		if !FileAccess.file_exists(location_file):
 			continue
 		var location = FileAccess.get_file_as_string(location_file)
+		if !FileAccess.file_exists(location):
+			pprint("Browser::PackageNotFound::source::%s" % location_file, false)
+			pprint("Browser::PackageNotFound::package::%s" % location, false)
+			continue
+
 		load_package(location)
 
 #----------------------------------------


### PR DESCRIPTION
Hi,
if a package saved in any `location.txt` does not exist anymore, it ends up with a crash as it tries to process it.

This should prevent that from happening.